### PR TITLE
Improve style of undershoots

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -4,10 +4,12 @@
   color: inherit;
 }
 
-.scrolled-window undershoot.bottom {
-  border-bottom: 1px solid #ededed;
+.scrolled-window undershoot.top {
+  box-shadow: inset 0 1px alpha(@shade_color, .75);
+  background: linear-gradient(to bottom, alpha(@shade_color, .75), transparent 4px);
 }
 
-.scrolled-window.top-undershoot undershoot.top {
-  border-top: 1px solid #ededed;
+.scrolled-window undershoot.bottom {
+  box-shadow: inset 0 -1px alpha(@shade_color, .75);
+  background: linear-gradient(to top, alpha(@shade_color, .75), transparent 4px);
 }


### PR DESCRIPTION
Improve style of undershoots when text overflows, ported from [GNOME Builder](https://gitlab.gnome.org/GNOME/gnome-builder/-/blob/main/src/libide/gui/style.css#L55-65) which uses backported libadwaita 1.4 undershoots

![Снимок экрана от 2023-04-28 05-59-00](https://user-images.githubusercontent.com/77155297/235049181-593804e8-fe97-4bee-b76b-2a834fddcb29.png)