### PR TITLE
Appdata related patches

### DIFF
--- a/data/io.github.fkinoshita.Telegraph.metainfo.xml.in.in
+++ b/data/io.github.fkinoshita.Telegraph.metainfo.xml.in.in
@@ -26,6 +26,8 @@
   </recommends>
   <url type="homepage">https://github.com/fkinoshita/Telegraph</url>
   <url type="bugtracker">https://github.com/fkinoshita/Telegraph/issues</url>
+  <url type="vcs-browser">https://github.com/fkinoshita/Telegraph/</url>
+  <url type="translate">https://github.com/fkinoshita/Telegraph/tree/main/po</url>
   <url type="donation">https://ko-fi.com/fkinoshita</url>
   <screenshots>
     <screenshot type="default">

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,9 +1,10 @@
+# Please keep the language entries alphabetical.
+bg
 cs
 fr
+hy
 it
 nl
 pt_BR
-tr
 ru
-bg
-hy
+tr


### PR DESCRIPTION
### appdata: add vcs-browser and translate support

These URLs are visible on Flathub and GNOME Control Center.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url

### po: re-order LINGUAS

Please keep the language entries alphabetical.