### PR TITLE
appdata: Remove Purism metadata

### DIFF
--- a/data/io.github.fkinoshita.Telegraph.metainfo.xml.in.in
+++ b/data/io.github.fkinoshita.Telegraph.metainfo.xml.in.in
@@ -122,8 +122,6 @@
     <kudo>ModernToolkit</kudo>
   </kudos>
   <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
     <value key="GnomeSoftware::key-colors">[(76, 113, 160), (100, 149, 211)]</value>
   </custom>
 </component>


### PR DESCRIPTION
This metadata is invalid: custom data is a dictionary and using the same key multiple times in a dictionary does not work

More information: https://github.com/ximion/appstream/issues/476