### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/build-aux/io.github.fkinoshita.Telegraph.Devel.json
+++ b/build-aux/io.github.fkinoshita.Telegraph.Devel.json
@@ -26,6 +26,7 @@
             "name" : "telegraph",
             "builddir" : true,
             "buildsystem" : "meson",
+            "run-tests": true,
 			"config-opts" : [
 				"-Dprofile=development"
 			],

--- a/data/io.github.fkinoshita.Telegraph.metainfo.xml.in.in
+++ b/data/io.github.fkinoshita.Telegraph.metainfo.xml.in.in
@@ -4,7 +4,11 @@
 	<id>@APPID@</id>
   <launchable type="desktop-id">@APPID@.desktop</launchable>
   <name translatable="no">@NAME@</name>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Felipe Kinoshita</developer_name>
+  <developer id="github.com">
+      <name translatable="no">Felipe Kinoshita</name>
+  </developer>
   <update_contact>kinofhek@gmail.com</update_contact>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-only</project_license>

--- a/data/meson.build
+++ b/data/meson.build
@@ -75,13 +75,13 @@ metainfo = i18n.merge_file(
   po_dir: join_paths(meson.project_source_root(), 'po')
 )
 
-# Validating the metainfo file
-appstreamcli = find_program('appstream-util', required: false)
-if appstreamcli.found()
-  test (
-    'Validate metainfo file',
+# Validate Appdata
+appstreamcli = find_program('appstreamcli', required: false)
+if (appstreamcli.found())
+  test('Validate metainfo file',
     appstreamcli,
-    args: ['validate-relax', '--nonet', join_paths(meson.current_build_dir (), application_id + '.metainfo.xml')]
+    args: ['validate', '--no-net', '--explain', metainfo],
+    workdir: meson.current_build_dir()
   )
 endif
 


### PR DESCRIPTION
- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Use appstreamcli to validate appdata
- Activate meson tests on flatpak manifest