### PR TITLE
Update developer ID

### DIFF
--- a/data/io.github.fkinoshita.Telegraph.metainfo.xml.in.in
+++ b/data/io.github.fkinoshita.Telegraph.metainfo.xml.in.in
@@ -6,7 +6,7 @@
   <name translatable="no">@NAME@</name>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Felipe Kinoshita</developer_name>
-  <developer id="github.com">
+  <developer id="io.github.fkinoshita">
       <name translatable="no">Felipe Kinoshita</name>
   </developer>
   <update_contact>kinofhek@gmail.com</update_contact>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDs.

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer