### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/io.github.fkinoshita.Telegraph.metainfo.xml.in.in
+++ b/data/io.github.fkinoshita.Telegraph.metainfo.xml.in.in
@@ -3,11 +3,11 @@
 <component type="desktop">
 	<id>@APPID@</id>
   <launchable type="desktop-id">@APPID@.desktop</launchable>
-  <name translatable="no">@NAME@</name>
+  <name translate="no">@NAME@</name>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
-  <developer_name translatable="no">Felipe Kinoshita</developer_name>
+  <developer_name translate="no">Felipe Kinoshita</developer_name>
   <developer id="github.com">
-      <name translatable="no">Felipe Kinoshita</name>
+      <name translate="no">Felipe Kinoshita</name>
   </developer>
   <update_contact>kinofhek@gmail.com</update_contact>
 	<metadata_license>CC0-1.0</metadata_license>
@@ -49,7 +49,7 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="0.1.8" date="2023-11-06">
-      <description translatable="no">
+      <description translate="no">
         <p>This release makes Telegraph inline with other GNOME 45 apps</p>
         <ul>
           <li>Use of the newer widgets, making Telegraph more consistent with other apps</li>
@@ -60,7 +60,7 @@
       </description>
     </release>
     <release version="0.1.7" date="2023-06-17">
-      <description translatable="no">
+      <description translate="no">
         <p>This is minor release of Telegraph brings some improvements nicer looking:</p>
         <ul>
           <li>Remove margins from text views</li>
@@ -71,7 +71,7 @@
       </description>
     </release>
     <release version="0.1.6" date="2023-05-25">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Improve undershoot styles (daudix-UFO)</li>
           <li>Add Russian translations (daudix-UFO)</li>
@@ -80,7 +80,7 @@
       </description>
     </release>
     <release version="0.1.5" date="2023-04-24">
-      <description translatable="no">
+      <description translate="no">
         <p>This is the first release after Telegraph entered GNOME Circle!</p>
         <ul>
           <li>Start text views with the "SOS" text, this makes it easier to understand that users should edit the text views.</li>
@@ -90,7 +90,7 @@
       </description>
     </release>
     <release version="0.1.4" date="2023-04-07">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Remember and restore window size</li>
           <li>Add Italian translations (albanobattistella)</li>
@@ -98,7 +98,7 @@
       </description>
     </release>
     <release version="0.1.3" date="2023-04-01">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Ctrl+W now closes the window</li>
           <li>Add French translations (Amerey)</li>
@@ -107,7 +107,7 @@
       </description>
     </release>
     <release version="0.1.2" date="2023-03-31">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Small user interface improvements</li>
           <li>Use nicer colors for GNOME Software carousel tile</li>
@@ -116,7 +116,7 @@
       </description>
     </release>
     <release version="0.1.1" date="2023-03-29">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Remove explicit modes, you can now start typing on either text views (axtloss)</li>
           <li>Layout is now responsive (gregorni)</li>
@@ -126,7 +126,7 @@
       </description>
     </release>
     <release version="0.1.0" date="2023-03-24">
-      <description translatable="no">
+      <description translate="no">
         <p>First release of Telegraph</p>
       </description>
     </release>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html